### PR TITLE
unicode range extended to \x10ffff

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Perl extension Email::MIME::RFC2047
 
+0.92
+        - Unicode range extended to 0x10ffff
+
 0.91
         - Allow some more characters in local parts
           Thanks to Joel Stevenson for the report

--- a/lib/Email/MIME/RFC2047/Decoder.pm
+++ b/lib/Email/MIME/RFC2047/Decoder.pm
@@ -25,7 +25,7 @@ my $encoded_word_text_re = qr/
             )+
         ) |
         [Qq] \?
-        ( [^?\x00-\x20\x7f-\x{ffff}]+ )
+        ( [^?\x00-\x20\x7f-\x{10ffff}]+ )
     )
     \? =
     (?= \z | \s )
@@ -45,7 +45,7 @@ my $encoded_word_phrase_re = qr/
             )+
         ) |
         [Qq] \?
-        ( [^?\x00-\x20$rfc_specials\x7f-\x{ffff}]+ )
+        ( [^?\x00-\x20$rfc_specials\x7f-\x{10ffff}]+ )
     )
     \? =
     (?= \z | [\s$rfc_specials_no_quote] )

--- a/lib/Email/MIME/RFC2047/Encoder.pm
+++ b/lib/Email/MIME/RFC2047/Encoder.pm
@@ -68,7 +68,7 @@ sub _encode {
 
         my $word_type;
 
-        if($word =~ /[\x80-\x{ffff}]|(^=\?.*\?=\z)/s) {
+        if($word =~ /[\x80-\x{10ffff}]|(^=\?.*\?=\z)/s) {
             # also encode any word that starts with '=?' and ends with '?='
             $word_type = 'mime';
         }
@@ -109,7 +109,7 @@ sub _encode {
                     # special character
                     $chunk = sprintf('=%02x', ord($char));
                 }
-                elsif($char =~ /[\x80-\x{ffff}]/) {
+                elsif($char =~ /[\x80-\x{10ffff}]/) {
                     # non-ASCII character
 
                     my $enc_char = $encoder->encode($char);


### PR DESCRIPTION
Email::MIME::RFC2047::Encoder doesn't encode THUMBS UP SIGN 0x1F44D
