### PR TITLE
Perl5.8 support

### DIFF
--- a/lib/Email/MIME/RFC2047/Decoder.pm
+++ b/lib/Email/MIME/RFC2047/Decoder.pm
@@ -85,13 +85,16 @@ my $quoted_string_re = qr/
     "
 /sx;
 
-my $comment_re = qr/
+our $COMMENT_RE;
+my $nested_comment_expression
+    = $^V lt v5.10.0 ? qr/(??{ $COMMENT_RE })/ : '(?-1)';
+my $comment_re = $COMMENT_RE = qr/
     (
         \(
             (?>(?:
                 (?>[^()\\]+) |
                 \\ . |
-                (?-1)
+                $nested_comment_expression
             )*)
         \)
     )

--- a/lib/Email/MIME/RFC2047/Decoder.pm
+++ b/lib/Email/MIME/RFC2047/Decoder.pm
@@ -18,17 +18,17 @@ my $rfc_specials_no_quote = '()<>\[\]:;\@\\,';
 # Captures ($encoding, $content_b, $content_q)
 my $encoded_word_text_re = qr/
     (?: ^ | (?<= [\r\n\t ] ) )
-    = \? ( [A-Za-z0-9_-]++ ) \?
+    = \? ( (?>[A-Za-z0-9_-]+) ) \?
     (?:
         [Bb] \?
         (
-            (?:
+            (?>(?:
                 [A-Za-z0-9+\/]{2}
                 (?: == | [A-Za-z0-9+\/] [A-Za-z0-9+\/=] )
-            )++
+            )+)
         ) |
         [Qq] \?
-        ( [\x21-\x3E\x40-\x7E]++ )
+        ( (?>[\x21-\x3E\x40-\x7E]+) )
     )
     \? =
     (?= \z | [\r\n\t ] )
@@ -38,17 +38,17 @@ my $encoded_word_text_re = qr/
 # Also matches after and before special chars (why?).
 my $encoded_word_phrase_re = qr/
     (?: ^ | (?<= [\r\n\t $rfc_specials_no_quote] ) )
-    = \? ( [A-Za-z0-9_-]++ ) \?
+    = \? ( (?>[A-Za-z0-9_-]+) ) \?
     (?:
         [Bb] \?
         (
-            (?:
+            (?>(?:
                 [A-Za-z0-9+\/]{2}
                 (?: == | [A-Za-z0-9+\/] [A-Za-z0-9+\/=] )
-            )++
+            )+)
         ) |
         [Qq] \?
-        ( [A-Za-z0-9!*+\/=_-]++ )
+        ( (?>[A-Za-z0-9!*+\/=_-]+) )
     )
     \? =
     (?= \z | [\r\n\t $rfc_specials_no_quote] )
@@ -77,10 +77,10 @@ my $encoded_word_phrase_re = qr/
 my $quoted_string_re = qr/
     "
     (
-        (?:
-            [^"\\]++ |
+        (?>(?:
+            (?>[^"\\]+) |
             \\ .
-        )*+
+        )*)
     )
     "
 /sx;
@@ -88,11 +88,11 @@ my $quoted_string_re = qr/
 my $comment_re = qr/
     (
         \(
-            (?:
-                [^()\\]++ |
+            (?>(?:
+                (?>[^()\\]+) |
                 \\ . |
                 (?-1)
-            )*+
+            )*)
         \)
     )
 /sx;


### PR DESCRIPTION
Hi, first of all, I would like to thank you for creating the greate package.

I found that your package has discarded perl5.8 support and I'm trying to take that back.
Although I still working on perl5.8, I would migrate tons of e-mail related legacy perl scripts to use `Email::MIME` and your `Email::MIME::RFC2047`.
Because `Encode::HTML::Header` broke backward-compatibility after version 2.80 and there is no way to create acceptable mail headers without non-core modules any more.

Do you happen to have any idea to support perl5.8 again?
It seems like all of compatibility issues are about to new regexp syntax that introduced in perl5.10.

Thanks,